### PR TITLE
Support for static framework

### DIFF
--- a/MPEdn.xcodeproj/project.pbxproj
+++ b/MPEdn.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 				INFOPLIST_FILE = MPEdnFwk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = scramjet.MPEdnFwk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -528,6 +529,7 @@
 				INFOPLIST_FILE = MPEdnFwk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = scramjet.MPEdnFwk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -568,6 +570,7 @@
 				INFOPLIST_FILE = MPEdnFwk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = scramjet.MPEdnFwk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
This improves #3 by having Carthage generate a static framework.

The advantage is that the produced fat library (i.e. contains architectures for both real devices and the simulator) packaged inside the framework, being a static object file, releases the burden of stripping the simulator archs when archiving an app for submission to the App Store (otherwise, it would get rejected).