### PR TITLE
Support 64-bit (signed integer) precision integers on 32-bit devices

### DIFF
--- a/MPEdn/MPEdnParser.m
+++ b/MPEdn/MPEdnParser.m
@@ -423,12 +423,12 @@ static BOOL is_sym_punct (unichar ch)
     
     char *numberStrEnd = (char *)numberStrUtf8;
 
-    long int number = strtol (numberStrUtf8, &numberStrEnd, 10);
+    long long number = strtoll (numberStrUtf8, &numberStrEnd, 10);
     
     if (numberStrEnd - numberStrUtf8 == endIdx - startIdx)
     {
       token = TOKEN_NUMBER;
-      tokenValue = [NSNumber numberWithLong: number];
+      tokenValue = [NSNumber numberWithLongLong: number];
     } else
     {
       [self raiseError: ERROR_INVALID_NUMBER


### PR DESCRIPTION
Devices with 32-bit CPUs (like the iPhone 5) currently get `2147483647` when parsing an EDN integer larger than `Int32.max`.

This PR aligns MPEdn to the EDN [format spec](https://github.com/edn-format/edn#user-content-integers):

> 64-bit (signed integer) precision is expected.

for integers on such devices.