### PR TITLE
Support parsing ISO 8601 dates (1972-01-01T12:00:00.000Z)

### DIFF
--- a/MPEdnTests/MPEdnParserTests.m
+++ b/MPEdnTests/MPEdnParserTests.m
@@ -251,10 +251,9 @@
     NSDate *correctDate = [NSDate dateWithTimeIntervalSince1970: 63115200];
 
     MPAssertParseOK (@"#inst \"1972-01-01T12:00:00.00-00:00\"", correctDate, @"Date");
-
-    // these formats used to parse under older iOS's but do not any more
-    //MPAssertParseOK (@"#inst \"1972-01-01T12:00:00.00Z\"", correctDate, @"Date");
-    //MPAssertParseOK (@"#inst \"1972-01-01T22:30:00.00+10:30\"", correctDate, @"Date");
+    MPAssertParseOK (@"#inst \"1972-01-01T22:30:00.00+10:30\"", correctDate, @"Date");
+    MPAssertParseOK (@"#inst \"1972-01-01T12:00:00.000Z\"", correctDate, @"Date");
+    MPAssertParseOK (@"#inst \"1972-01-01T12:00:00.000\"", correctDate, @"Date");
   }
 
   // UUID


### PR DESCRIPTION
This PR adds support for reading dates optionally ending with `Z`, while keeping the current format for writing dates (this is why two `NSDateFormatter` are used).

Parsing `1972-01-01T12:00:00.00-00:00` (with timezone) no longer works. This could be implemented by using two `NSDateFormatter` for parsing: trying one and checking wether it parsed (result != `nil`) and then using the other one. But since nobody really serializes dates like that, initially I didn't implement this solution (I will if you feel it's needed).

Thanks!